### PR TITLE
Bug fix proposal: Handle errors appearing when trying to close closed…

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,4 +573,4 @@ Examples:
 
 * verx\_client\_tcp
     * gen\_server halts when receiving a tcp\_closed message, causes an
-      error if the caller does a verx\_client:close/1
+      error if the caller does a verx\_client:stop/1

--- a/src/verx_client.erl
+++ b/src/verx_client.erl
@@ -73,7 +73,8 @@ start_link(Arg) ->
     gen_server:start_link(Transport, [Self, Arg], []).
 
 stop(Ref) when is_pid(Ref) ->
-    gen_server:call(Ref, stop).
+    catch gen_server:call(Ref, stop),
+    ok.
 
 
 call(Ref, Proc) ->


### PR DESCRIPTION
… (or nonexisting ports). Also avoid sending stop call to verx_client_unix gen_server when receiving EXIT info from libvirtd, as this causes another error. Fixed typo in README.

I'm doing tests where I launch and remove around 10 Ubuntu VMs using verx. In these tests, I have encountered two errors:

(1) As libvirtd sends EXIT (line 147 of verx_client_unix.erl), previously an attempt to shut down the affected gen_server was made. This results the following errors: {{shutdown,normal} ,{gen_server,call,[<0.180.0>,stop]}}. Do you agree that when libvirtd sends EXIT, the process stops anyway, and therefore stopping it again yields this error? Or am I mistaken? This error is rare and happens ~1 time per all calls made when starting 10 VMs. I ran length(erlang:processes()) at times between creating and destroying sets of 10 VMs, it seems the total amount of processes stays stable when not stopping the gen_servers as before.

(2) Fairly often, when calling erlang:port_close (line 155/156 of verx_client_unix.erl), a badarg error is raised. I have no idea on how to solve this, but I suggest that we catch this error in the mean time. I could look further into this if you have any ideas on why this might be.