### PR TITLE
mk_libvirt_constants: Handle spaces in "# define"

### DIFF
--- a/bin/mk_libvirt_constants
+++ b/bin/mk_libvirt_constants
@@ -67,5 +67,15 @@ function define(name, val, comment) {
         if ($0 ~ /^[0-9+\(\)]+$/) {
             print define(name, $0, "")
         }
+    } else if (/^#\s+define/ && $3 ~ /^VIR_/) {
+        name = $3
+
+        $1 = ""
+        $2 = ""
+        $3 = ""
+        gsub("\\s", "", $0)
+        if ($0 ~ /^[0-9+\(\)]+$/) {
+            print define(name, $0, "")
+        }
     }
 }


### PR DESCRIPTION
Constants have the syntax:

    # define VIR_NODE_MEMORY_STATS_FIELD_LENGTH 80

Otherwise we're lacking several constants to rebuild against recent
libvirt.